### PR TITLE
Fix: split indexing [Fixes #12]

### DIFF
--- a/src/utils/split.js
+++ b/src/utils/split.js
@@ -1,10 +1,8 @@
 module.exports = ({ params }) => {
   const [value, delimiter, index] = params;
+  const splitArray = value.split(delimiter);
 
   return {
-    value:
-      typeof index === 'number'
-        ? value.split(delimiter)[index]
-        : value.split(delimiter),
+    value: index !== undefined ? splitArray[index] : splitArray,
   };
 };


### PR DESCRIPTION
When specifying an index to the `split()` function, the entire list of split items would be returned.

Example/snippet `serverless.yaml`
```
custom:
  moniker: "ABCD-DEV-USWEST2"
  moniker_split: ${split(${self:custom.adsk_moniker,'-'})}
  moniker_name: ${split(${self:custom.adsk_moniker,'-',0})}
  moniker_env: ${split(${self:custom.adsk_moniker,'-',1})}
  moniker_region: ${split(${self:custom.adsk_moniker,'-',2})}
```

Bug:
```
$ npx sls print -s dev --path custom
moniker: ABCD-DEV-USWEST2
moniker_split:
  - ABCD
  - DEV
  - USWEST2
moniker_name:
  - ABCD
  - DEV
  - USWEST2
moniker_env:
  - ABCD
  - DEV
  - USWEST2
moniker_region:
  - ABCD
  - DEV
  - USWEST2
```

Fix:
```
$ npx sls print -s dev --path custom
moniker: ABCD-DEV-USWEST2
moniker_split:
  - ABCD
  - DEV
  - USWEST2
moniker_name: ABCD
moniker_env: DEV
moniker_region: USWEST2
```

Fixes #12 